### PR TITLE
[Feature #158787482] Improve gradle builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,8 @@ android {
 
 
 dependencies {
+
+    //      Dependencies
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "com.android.support:appcompat-v7:$rootProject.supportLibraryVersion"
     implementation "com.android.support:design:$rootProject.supportLibraryVersion"
@@ -57,6 +59,7 @@ dependencies {
     implementation "com.squareup.retrofit2:retrofit:$rootProject.retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$rootProject.retrofitVersion"
 
+    //    Glide Dependencies
     implementation "com.github.bumptech.glide:glide:$rootProject.glideVersion"
     annotationProcessor "com.github.bumptech.glide:compiler:$rootProject.glideVersion"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,12 +6,12 @@ apply from: "$project.rootDir/tools/script-checkstyle.gradle"
 apply from: "$project.rootDir/tools/quality.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion rootProject.myCompileSdkVersion
 
     defaultConfig {
         applicationId "com.rosen.wasswaderick.nairobijavageeks"
-        minSdkVersion 16
-        targetSdkVersion 28
+        minSdkVersion rootProject.myMinSdkVersion
+        targetSdkVersion rootProject.myTargetSdkVersion
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -39,30 +39,26 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support:design:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation 'com.android.support:design:28.0.0'
+    implementation "com.android.support:appcompat-v7:$rootProject.supportLibraryVersion"
+    implementation "com.android.support:design:$rootProject.supportLibraryVersion"
+    implementation "com.android.support.constraint:constraint-layout:$rootProject.constraintLayoutVersion"
+    testImplementation "junit:junit:$rootProject.junitVersion"
+    androidTestImplementation "com.android.support.test:runner:$rootProject.testRunnerVersion"
+    androidTestImplementation "com.android.support.test.espresso:espresso-core:$rootProject.expressoVersion"
+    implementation "com.android.support:design:$rootProject.supportLibraryVersion"
 
     //    Developer avatar
-    implementation 'de.hdodenhof:circleimageview:2.1.0'
-    implementation 'com.android.support:cardview-v7:28.0.0'
-    implementation 'com.android.support:recyclerview-v7:28.0.0'
-    implementation 'com.android.support:support-v4:28.0.0'
+    implementation "de.hdodenhof:circleimageview:$rootProject.circleImageVersion"
+    implementation "com.android.support:cardview-v7:$rootProject.supportLibraryVersion"
+    implementation "com.android.support:recyclerview-v7:$rootProject.supportLibraryVersion"
+    implementation "com.android.support:support-v4:$rootProject.supportLibraryVersion"
 
     //    Retrofit Responses
-    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
+    implementation "com.squareup.retrofit2:retrofit:$rootProject.retrofitVersion"
+    implementation "com.squareup.retrofit2:converter-gson:$rootProject.retrofitVersion"
 
-    //    Retrofit Responses
-    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.4.0'
-
-    implementation 'com.github.bumptech.glide:glide:4.8.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.8.0'
+    implementation "com.github.bumptech.glide:glide:$rootProject.glideVersion"
+    annotationProcessor "com.github.bumptech.glide:compiler:$rootProject.glideVersion"
 
 }
 

--- a/app/src/main/java/com/rosen/wasswaderick/nairobijavageeks/view/PresenterView.java
+++ b/app/src/main/java/com/rosen/wasswaderick/nairobijavageeks/view/PresenterView.java
@@ -1,6 +1,5 @@
 package com.rosen.wasswaderick.nairobijavageeks.view;
 
-import com.rosen.wasswaderick.nairobijavageeks.model.User;
 
 /**
  * Created by Derick W on 25,September,2018

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,23 @@ allprojects {
     }
 }
 
+ext {
+    myBuildToolsVersion="28.0.0"
+    myMinSdkVersion=16
+    myTargetSdkVersion=28
+    myCompileSdkVersion=28
+
+    // dependencies versions
+    supportLibraryVersion = '28.0.0'
+    retrofitVersion = '2.4.0'
+    glideVersion = '4.8.0'
+    circleImageVersion = '2.1.0'
+    constraintLayoutVersion = '1.1.3'
+    junitVersion = '4.12'
+    testRunnerVersion = '1.0.2'
+    expressoVersion = '3.0.2'
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,4 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+org.gradle.caching=true


### PR DESCRIPTION
#### What does this PR do?
* Improve Gradle build speeds using Gradle Build Cache for Android.
* Manage dependency versions with variables defined in project ```build.gradle```.

#### Description of Task to be completed?
*  Centralize all dependence versions for reusability.
*  Enable Gradle Build Cache to improve Gradle builds (reduce the time for the builds).

#### How should this be manually tested?
* Clone the project, ```git clone https://github.com/wasswa-derick/NairobiJavaGeeks.git```.
* In your terminal, ```cd NairobiJavaGeeks```
* Checkout to the ```ft-improve-gradlebuilds-158787482``` branch.
* Run Gradle without cache by running this command in the terminal: ```./gradlew clean build --no-build-cache``` and record the build times.
* Run Gradle with build cache enabled by running ```./gradlew clean build --build-cache``` and record the build times.
* Observe the differences in the build times when build cache is enabled.

#### What are the relevant pivotal tracker stories?
[#158787096](https://www.pivotaltracker.com/story/show/158787096)
[#158787482](https://www.pivotaltracker.com/story/show/158787482)

#### ScreenShots

> Gradle Build Without Caching

<img width="945" alt="nocache" src="https://user-images.githubusercontent.com/39955231/46287110-27e0c200-c58a-11e8-98b9-363c7d9b8b3f.png">


> Gradle Build With Build Cache Enabled

<img width="1401" alt="saved" src="https://user-images.githubusercontent.com/39955231/46287118-2b744900-c58a-11e8-9212-836aaf2a61db.png">
